### PR TITLE
Small fix + precision on Cgroup error

### DIFF
--- a/docker/local/README.md
+++ b/docker/local/README.md
@@ -11,3 +11,4 @@
 ## Cgroup errors
 
  * On linux, you need to add `cgroup_enable=memory swapaccount=1` to your cmdline (e.g. `/etc/default/grub` and `sudo update-grub2`)
+ * It may be needed to add `systemd.unified_cgroup_hierarchy=0` too on some modern system

--- a/docker/production/docker-compose.yml
+++ b/docker/production/docker-compose.yml
@@ -45,7 +45,7 @@ services:
     
   domserver:
     container_name: domjudge
-    image: incaseoftrouble/ist_domserver:latest
+    image: incaseoftrouble/domtutor_domserver
     networks:
       - domjudge
     ports:
@@ -81,7 +81,7 @@ services:
   judgehost-1:
     container_name: judgehost-1
     hostname: judgedaemon-1
-    image: incaseoftrouble/ist_judgehost:latest
+    image: incaseoftrouble/domtutor_judgehost
     networks:
       - domjudge
     privileged: True
@@ -100,7 +100,7 @@ services:
   judgehost-2:
     container_name: judgehost-2
     hostname: judgedaemon-2
-    image: incaseoftrouble/ist_judgehost:latest
+    image: incaseoftrouble/domtutor_judgehost
     networks:
       - domjudge
     privileged: True
@@ -119,7 +119,7 @@ services:
   judgehost-3:
     container_name: judgehost-3
     hostname: judgedaemon-3
-    image: incaseoftrouble/ist_judgehost:latest
+    image: incaseoftrouble/domtutor_judgehost
     networks:
       - domjudge
     privileged: True


### PR DESCRIPTION
Hello !

I have changed to images referred in the production/docker-compose.yml to point to the correct image.

I also have added a line in the local README.md about the Cgroup error. On some system one more line should be added in order for the fix to work (caused by the presence of Cgroup v2 I think)